### PR TITLE
Add 10 second delay after agent init

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,4 +1,6 @@
 import os
+import time
+
 from dotenv import load_dotenv
 load_dotenv(verbose=True)
 
@@ -10,6 +12,9 @@ bearer_agent.init(
   secret_key=os.environ.get("BEARER_SECRET_KEY"),
   environment=os.environ.get("APP_ENV")
 )
+
+print("-- Waiting for initialization --")
+time.sleep(10)
 
 # Postman-echo
 print("-- Sending API calls to Postman-Echo --")


### PR DESCRIPTION
Environments are created asynchronously on the back-end. We must wait for that to happen so that all built-in rules have been created and sent to the agent.

This is a temporary measure until we fix this properly.